### PR TITLE
Added config entry to hide moving parts

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mc_version=1.16.5
 forge_version=36.1.0
-ccl_version=4.0.0.+
+ccl_version=4.0.2.+
 ccl_version_max=5.0.0
 mod_version=2.6.0
 cbmp_version=3.0.2.+

--- a/src/main/java/codechicken/translocators/handler/ConfigHandler.java
+++ b/src/main/java/codechicken/translocators/handler/ConfigHandler.java
@@ -19,6 +19,7 @@ public class ConfigHandler {
 
     public static ConfigTag config;
     public static boolean disableCraftingGrid;
+    public static boolean hideParticlesAndMovingParts;
     public static Tags.IOptionalNamedTag<Item> regulateTag;
 
     public static void init(Path file) {
@@ -31,6 +32,11 @@ public class ConfigHandler {
     public static void loadConfig() {
         disableCraftingGrid = config.getTag("disable_crafting_grid")
                 .setComment("Setting this to true will disable the placement of the CraftingGrid.")
+                .setDefaultBoolean(false)
+                .getBoolean();
+
+        hideParticlesAndMovingParts = config.getTag("disable_particles")
+                .setComment("Setting this to true will stop the client from rendering the moving parts, liquids and items")
                 .setDefaultBoolean(false)
                 .getBoolean();
 

--- a/src/main/java/codechicken/translocators/part/FluidTranslocatorPart.java
+++ b/src/main/java/codechicken/translocators/part/FluidTranslocatorPart.java
@@ -5,6 +5,7 @@ import codechicken.lib.math.MathHelper;
 import codechicken.multipart.api.MultiPartType;
 import codechicken.multipart.api.part.TMultiPart;
 import codechicken.translocators.client.render.RenderTranslocator;
+import codechicken.translocators.handler.ConfigHandler;
 import codechicken.translocators.init.TranslocatorsModContent;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -198,7 +199,10 @@ public class FluidTranslocatorPart extends TranslocatorPart {
 
     @Override
     public void renderDynamic(MatrixStack mStack, IRenderTypeBuffer buffers, int packedLight, int packedOverlay, float partialTicks) {
-        RenderTranslocator.renderFluid(this, mStack, buffers, partialTicks);
+        // // only render fluid, if not set to hidden in config
+        if (!ConfigHandler.hideParticlesAndMovingParts) {
+            RenderTranslocator.renderFluid(this, mStack, buffers, partialTicks);
+        }
         super.renderDynamic(mStack, buffers, packedLight, packedOverlay, partialTicks);
     }
 

--- a/src/main/java/codechicken/translocators/part/ItemTranslocatorPart.java
+++ b/src/main/java/codechicken/translocators/part/ItemTranslocatorPart.java
@@ -482,8 +482,11 @@ public class ItemTranslocatorPart extends TranslocatorPart implements IRedstoneP
 
     @Override
     public void renderDynamic(MatrixStack mStack, IRenderTypeBuffer buffers, int packedLight, int packedOverlay, float partialTicks) {
+        // only render items, if not set to hidden in config
+        if (!ConfigHandler.hideParticlesAndMovingParts) {
+            RenderTranslocator.renderItem(this, mStack, buffers, packedLight, packedOverlay, partialTicks);
+        }
         super.renderDynamic(mStack, buffers, packedLight, packedOverlay, partialTicks);
-        RenderTranslocator.renderItem(this, mStack, buffers, packedLight, packedOverlay, partialTicks);
     }
 
     @Override

--- a/src/main/java/codechicken/translocators/part/TranslocatorPart.java
+++ b/src/main/java/codechicken/translocators/part/TranslocatorPart.java
@@ -8,10 +8,14 @@ import codechicken.lib.raytracer.SubHitVoxelShape;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.RenderUtils;
 import codechicken.lib.vec.*;
-import codechicken.multipart.api.part.*;
+import codechicken.multipart.api.part.ITickablePart;
+import codechicken.multipart.api.part.TFacePart;
+import codechicken.multipart.api.part.TMultiPart;
+import codechicken.multipart.api.part.TNormalOcclusionPart;
 import codechicken.multipart.block.TileMultiPart;
 import codechicken.multipart.util.PartRayTraceResult;
 import codechicken.translocators.client.render.RenderTranslocator;
+import codechicken.translocators.handler.ConfigHandler;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.block.SoundType;
@@ -454,7 +458,10 @@ public abstract class TranslocatorPart extends TMultiPart implements TFacePart, 
         CCRenderState ccrs = CCRenderState.instance();
         ccrs.reset();
         RenderTranslocator.renderInsert(this, ccrs, mStack, buffers, packedLight, packedOverlay, partialTicks);
-        RenderTranslocator.renderLinks(this, ccrs, mStack, buffers);
+        // only render links, if not set to hidden in config
+        if (!ConfigHandler.hideParticlesAndMovingParts) {
+            RenderTranslocator.renderLinks(this, ccrs, mStack, buffers);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Idea
I had some performance issues with my Project Ozone 3 world.
I wasn't sure, if the particles and the rendered items were the problem but i thought it would be a good idea to add the ability to hide these.

# New Features
Now there is a new entry in the config called: "disable_particles"
This option can be set to true to prevent links, liquids and items from being rendered.

# Changes made in files
* build.properties: fixed version of ccl **(MC wasn't loading for me without updating this, please check!)**
* ConfigHandler: added entry in config to disable moving parts
* FluidTranslocatorPart: impl. config feature
* ItemTranslocatorPart: impl. config feature and adjusted render order to be in line with FluidTranslocatorPart
* TranslocatorPart: impl. config feature